### PR TITLE
Attempt to re-establish connections on error

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RemoteREPL"
 uuid = "1bd9f7bb-701c-4338-bec7-ac987af7c555"
 authors = ["Chris Foster <chris42f@gmail.com> and contributors"]
-version = "0.2.0"
+version = "0.2.1"
 
 [deps]
 OpenSSH_jll = "9bd350c2-7e96-507f-8002-3f2e150b4e1b"


### PR DESCRIPTION
This makes things a lot more usable when the remote server is restarted
or the connection drops for some other reason.

Introduces a `Connection` struct to hold connection parameters so that
we can reconnect later on demand.