### PR TITLE
Remote REPL help mode

### DIFF
--- a/src/server.jl
+++ b/src/server.jl
@@ -39,6 +39,12 @@ function serve_repl_session(socket)
                         show(io, MIME"text/plain"(), result)
                     end
                 response = (:eval_result, resultval)
+            elseif messageid == :help
+                resultval = format_result(display_properties) do io
+                    md = Main.eval(REPL.helpmode(io, value))
+                    show(io, MIME"text/plain"(), md)
+                end
+                response = (:help_result, resultval)
             elseif messageid == :display_properties
                 @debug "Got client display properties" display_properties
                 display_properties = value::Dict

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -100,6 +100,14 @@ try
     # Semicolon suppresses output
     @test runcommand("asdf;") == ""
 
+    # Help mode
+    @test occursin("helpmodetest documentation!",
+        begin
+            runcommand("function helpmodetest end")
+            runcommand("@doc \"helpmodetest documentation!\" helpmodetest")
+            runcommand("?helpmodetest")
+        end)
+
     # Execute a single command on a separate connection
     @test RemoteREPL.remote_eval(test_interface, test_port, "asdf") == "42\n"
 end


### PR DESCRIPTION
Useful for displaying help when the application on the remote side has
different modules from the local side.