### PR TITLE
`%get` and `%put` syntax to transfer values

### DIFF
--- a/src/server.jl
+++ b/src/server.jl
@@ -43,6 +43,14 @@ function serve_repl_session(socket)
                     end
                 end
                 response = (:eval_result, resultval)
+            elseif messageid == :eval_and_get
+                result = nothing
+                logstr = format_result(display_properties) do io
+                    result = with_logger(ConsoleLogger(io)) do
+                        Main.eval(value)
+                    end
+                end
+                response = (:eval_and_get_result, (result, logstr))
             elseif messageid == :help
                 resultval = format_result(display_properties) do io
                     md = Main.eval(REPL.helpmode(io, value))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -111,6 +111,15 @@ try
             runcommand("?helpmodetest")
         end)
 
+    # Copy variables or expressions between local and remote Main modules
+    @test RemoteREPL.run_remote_repl_command(conn, IOBuffer(), "%put asdf") == 42
+    @test Main.asdf == 42
+    @test RemoteREPL.run_remote_repl_command(conn, IOBuffer(), "%put qwer = asdf + 1") == 43
+    @test Main.qwer == 43
+    Main.eval(:(to_transfer = 102))
+    @test runcommand("%get to_transfer") == "102\n"
+    @test runcommand("to_transfer") == "102\n"
+
     # Execute a single command on a separate connection
     @test RemoteREPL.remote_eval(test_interface, test_port, "asdf") == "42\n"
 end


### PR DESCRIPTION
Syntax to allow transfer of variables between local and remote, rather
than their string representations.  This can be helpful if the local
side has resources such as plotting infrastructure which is not
available on the remote.

Get the value of expression `r = rhs` on the client and evaluate
`lhs = r` on the server:

    remote> %get lhs = rhs

Get the value of expression `r = rhs` on the server and evaluate
`lhs = r` on the client:

    remote> %put lhs = rhs

Closes #11