### PR TITLE
Add `@remote` macro for fetching expressions

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RemoteREPL"
 uuid = "1bd9f7bb-701c-4338-bec7-ac987af7c555"
 authors = ["Chris Foster <chris42f@gmail.com> and contributors"]
-version = "0.2.5"
+version = "0.2.6"
 
 [deps]
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ process and run commands interactively:
 
 * Run code in the `Main` module of a remote Julia process
 * Standard REPL tab completion and help mode with `?`
-* Transfer variables between processes with `%get` and `%put`
+* Transfer variables between processes with `@remote`
 * Automatic ssh tunnel for network security. Reconnects dropped connections.
 
 Read [**the latest documentation**](https://c42f.github.io/RemoteREPL.jl/dev) more information.

--- a/docs/src/howto.md
+++ b/docs/src/howto.md
@@ -1,6 +1,6 @@
 # How-To
 
-## Connecting to a remote machine
+## Connect to a remote server
 
 Connecting to a remote machine goes via an SSH tunnel by default.
 
@@ -18,47 +18,19 @@ Connecting to a remote machine goes via an SSH tunnel by default.
 3. Start a separate Julia process B on the client and call
    `connect_repl("your.host.example")`.
 
-## Transfer variables
+## Plot variables from the server
 
-Variable values can be transferred between server and client with the special
-syntax `%put` and `%get`:
+The [`@remote`](@ref) macro can be used to get variables from the server and
+plot them on the client with a single line of code. For example:
 
-* Transfer a value from a variable `x` on the server and assign it to the name
-  `x` on the client:
-  ```julia
-  remote> x = 42;
+```julia
+remote> x = 1:42; y = x.^2;
 
-  remote> %put x
-  42
+julia> plot(@remote((x,y))...)
+```
 
-  julia> x
-  42
-  ```
 
-* Transfer a variable to the server under a new name
-  ```julia
-  julia> y = 101;
-
-  remote> %get z = y
-  101
-  ```
-
-* More general expressions on the right and left hand sides also work:
-  ```julia
-  remote> x = [1,2];
-
-  remote> %put y = x .+ 1
-  2-element Vector{Int64}:
-   2
-   3
-
-  remote> %put a,b = x
-  2-element Vector{Int64}:
-   1
-   2
-  ```
-
-## Alternatives to SSH
+## Use alternatives to SSH
 
 ### AWS Session Manager
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -5,7 +5,7 @@ process and run commands interactively:
 
 * Run code in the `Main` module of a remote Julia process
 * Standard REPL tab completion and help mode with `?`
-* Transfer variables between processes with `%get` and `%put`
+* Transfer variables between processes with `@remote`
 * Automatic ssh tunnel for network security. Reconnects dropped connections.
 
 ## Demo

--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -2,21 +2,16 @@
 
 ## REPL syntax
 
-RemoteREPL syntax is just normal julia REPL syntax with minor additions:
-
-* `?expr` produces help for `expr`. This is just like the normal REPL, but we
-  don't have a separate help mode.
-* `%get lhs = rhs` evaluates `rhs` on the client and assigns to `lhs` on the
-  remote server.
-* `%put lhs = rhs` evaluates `rhs` on the server and assigns to `lhs` on the
-  client.
-* `%get x` is shorthand for `%get x = x`, and similarly for `%put`.
+RemoteREPL syntax is just normal Julia REPL syntax, the only minor difference
+is that `?expr` produces help for `expr`, but we don't have a separate help
+mode for this.
 
 ## API reference
 
 ```@docs
 connect_repl
 serve_repl
+RemoteREPL.@remote
 RemoteREPL.remote_eval
 ```
 

--- a/docs/src/tutorial.md
+++ b/docs/src/tutorial.md
@@ -34,28 +34,32 @@ julia> x
 123
 ```
 
-## Transfer variables between client and server
+## Transferring variables
 
 Normally RemoteREPL shows you a string-based summary of variables, but the
 actual Julia values are held in the remote process. Sometimes it's useful to
 transfer these to the client to make use of graphical utilities like plotting
 or other resources which you need a local copy of the object for. This can be
-done with the RemoteREPL `%get` and `%put` syntax:
+done with the RemoteREPL [`@remote`](@ref) macro which executes an expression
+on the "other side" of the current remote connection.
 
-Transfer the value from a variable `x` on the server and assign it to the name
-`x` on the client. In process B from the previous tutorial, run
+Transfer the value from a variable `x` on the client to the variable `y` on the
+server:
 
 ```julia
-remote> y = 42;
+julia> x = [1,2];
 
-remote> %put y
-42
+remote> y = @remote(x)
+2-element Vector{Int64}:
+ 1
+ 2
 ```
 
-Now switching back to the local REPL (press backspace), you can see the value
-of `y` has been set locally.
+Transfer arrays `x` and `y` from the server and plot them on the client:
 
 ```julia
-julia> y
-42
+remote> x = 1:42; y = x.^2;
+
+julia> a, b = @remote (x,y)
+       plot(a, b)
 ```

--- a/src/RemoteREPL.jl
+++ b/src/RemoteREPL.jl
@@ -1,6 +1,6 @@
 module RemoteREPL
 
-export connect_repl, serve_repl
+export connect_repl, serve_repl, @remote
 
 # Technically, server and client could be completely separate packages, but
 # having them together seems simplest for now.

--- a/src/client.jl
+++ b/src/client.jl
@@ -360,15 +360,6 @@ This can be used in both directions:
 
 # Examples
 
-Fetch a value from the server to the client:
-
-```
-remote> server_val = 1:10;
-
-julia> client_val = @remote server_val
-1:10
-```
-
 Push a value from the client to the server:
 
 ```

--- a/src/client.jl
+++ b/src/client.jl
@@ -262,8 +262,10 @@ that `host` needs to be running an ssh server and you need ssh credentials set
 up for use on that host. For secure networks this can be disabled by setting
 `tunnel=:none`.
 
-To provide extra options to SSH, you may use the `ssh_opts` keyword, for example an identity file may be set with  `` ssh_opts = `-i /path/to/identity.pem` ``.
-Alternatively, you may want to set this up permanently using a `Host` section in your ssh config file.
+To provide extra options to SSH, you may use the `ssh_opts` keyword, for
+example an identity file may be set with ```ssh_opts = `-i /path/to/identity.pem` ```.
+Alternatively, you may want to set this up permanently using a `Host` section
+in your ssh config file.
 
 You can also use the following technologies for tunneling in place of SSH:
 1) AWS Session Manager: set `tunnel=:aws`. The optional `region` keyword argument can be used to specify the AWS Region of your server.

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -117,15 +117,6 @@ try
     @test Main.clientside_var == 0:41
     @test @remote(conn, serverside_var) == 1:42
 
-    # Copy variables or expressions between local and remote Main modules
-    @test RemoteREPL.run_remote_repl_command(conn, IOBuffer(), "%put asdf") == 42
-    @test Main.asdf == 42
-    @test RemoteREPL.run_remote_repl_command(conn, IOBuffer(), "%put qwer = asdf + 1") == 43
-    @test Main.qwer == 43
-    Main.eval(:(to_transfer = 102))
-    @test runcommand("%get to_transfer") == "102\n"
-    @test runcommand("to_transfer") == "102\n"
-
     # Execute a single command on a separate connection
     @test RemoteREPL.remote_eval(test_interface, test_port, "asdf") == "42\n"
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -111,6 +111,12 @@ try
             runcommand("?helpmodetest")
         end)
 
+    # Test the @remote macro
+    Main.eval(:(clientside_var = 0:41))
+    @test runcommand("serverside_var = 1 .+ @remote clientside_var") == "1:42\n"
+    @test Main.clientside_var == 0:41
+    @test @remote(conn, serverside_var) == 1:42
+
     # Copy variables or expressions between local and remote Main modules
     @test RemoteREPL.run_remote_repl_command(conn, IOBuffer(), "%put asdf") == 42
     @test Main.asdf == 42


### PR DESCRIPTION
`@remote` synchronously executes an expression and fetches the resulting
value from the other end of the current RemoteREPL connection.  It can
be used to both push data to the server and fetch data back to the
client.

Probably obsoletes the %put and %get RemoteREPL magics.