### PR TITLE
Support for `@remote(stdout)`

### DIFF
--- a/docs/src/design.md
+++ b/docs/src/design.md
@@ -1,13 +1,33 @@
 # Design
 
+## REPL wire protocol
+
+Currently RemoteREPL uses the standard `Serialization` library to format
+messages on the wire because this is simple to use.  However, this is not
+bidirectionally compatible between Julia versions so we'll probably move to a
+different message container format in the future.
+
 RemoteREPL formats results as text (using `show(io, "text/plain", result)`) for
-communication back to the client terminal. This is helpful because:
+communication back to the client. This is helpful because:
 * The result of a computation might be large, and it should be summarized
-  before sending back.
+  before sending back. `show` is an excellent tool for this.
 * The remote machine may be a separate application with different modules
   loaded; it may not be possible to deserialize the results in the local Julia
-  session.
+  session when custom types are involved.
 
-Currently RemoteREPL uses the standard Serialization library to format messages
-on the wire, but this isn't bidirectionally compatible between Julia versions
-so we'll probably move to something else in the future.
+## The standard streams
+
+`RemoteREPL` doesn't interact with the standard streams `stdout`,`stderr` and
+`stdin` on the server. This avoids unexpected side effects such as interfereing
+with the server's normal logging and clashing with any concurrent `RemoteREPL`
+sessions.
+
+However this means that `RemoteREPL` misses out on some behavior you'd expect
+from the normal `REPL`:
+1. Functions like `println()` have side effects on the server which are not
+   visible on the client. See the howto for how `@remote(stdout)` helps with
+   this.
+1. Interactive utilities like `Cthulhu.jl` — which reads from `stdin` and
+   writes to `stdout` — don't work.
+
+In future I hope to improve this situation with better stream forwarding utilities.

--- a/docs/src/howto.md
+++ b/docs/src/howto.md
@@ -40,6 +40,39 @@ julia@your.host> x = 1:42; y = x.^2;
 julia> plot(@remote((x,y))...)
 ```
 
+## Use `stdout` with `println`/`dump`, etc
+
+Lots of functions such as `print` write to the global `stdout` variable, but
+`RemoteREPL` doesn't capture this.
+
+There's two ways to get a similar effect in `RemoteREPL`, both of which rely on
+passing an `IO` object explicitly to `println`/`dump`/etc.
+
+One way is to use `@remote(stdout)` which creates a proxy of the client's
+`stdout` stream on the server which you can write to:
+
+```julia
+julia@localhost> dump(@remote(stdout), :(a + b))
+Expr
+  head: Symbol call
+  args: Array{Any}((3,))
+    1: Symbol +
+    2: Symbol a
+    3: Symbol b
+```
+
+Another way is to use `sprint` to create the `IO` object and wrap the returned
+value in a `Text` object for display:
+
+```julia
+julia@localhost> Text(sprint(dump, :(a+b)))
+Expr
+  head: Symbol call
+  args: Array{Any}((3,))
+    1: Symbol +
+    2: Symbol a
+    3: Symbol b
+```
 
 ## Use alternatives to SSH
 

--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -6,15 +6,6 @@ RemoteREPL syntax is just normal Julia REPL syntax, the only minor difference
 is that `?expr` produces help for `expr`, but we don't have a separate help
 mode for this.
 
-## API reference
-
-```@docs
-connect_repl
-serve_repl
-RemoteREPL.@remote
-RemoteREPL.remote_eval
-```
-
 ## Security considerations
 
 Note that *any logged-in users on the client or server machines can execute
@@ -32,4 +23,13 @@ you'll be left with *no security whatsoever*.
 TLDR; this package aims to provide safe defaults for single-user machines.
 However, *do not expose the RemoteREPL port to an open network*. Abitrary
 remote code execution is the main feature provided by this package!
+
+## API reference
+
+```@docs
+connect_repl
+serve_repl
+RemoteREPL.@remote
+RemoteREPL.remote_eval
+```
 

--- a/src/RemoteREPL.jl
+++ b/src/RemoteREPL.jl
@@ -6,6 +6,8 @@ const DEFAULT_PORT = 27754
 const PROTOCOL_MAGIC = "RemoteREPL"
 const PROTOCOL_VERSION = UInt32(1)
 
+const STDOUT_PLACEHOLDER = Symbol("#RemoteREPL_STDOUT_PLACEHOLDER")
+
 include("tunnels.jl")
 include("server.jl")
 include("client.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -138,6 +138,9 @@ try
     @test @remote(conn, serverside_var) == 1:42
     @test_throws RemoteREPL.RemoteException @remote(conn, error("hi"))
 
+    # Special case handling of stdout
+    @test runcommand("println(@remote(stdout), \"hi\")") == "hi\n"
+
     # Execute a single command on a separate connection
     @test (RemoteREPL.remote_eval(test_interface, test_port, "asdf")::Text).content == "42"
 end


### PR DESCRIPTION
This adds support for forwarding a rough approximation of the client's
stdout stream to the server to allow printing of messages conforming to
the client's terminal size.