### PR TITLE
Client support for interrupting remote evaluations

### DIFF
--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -24,6 +24,16 @@ TLDR; this package aims to provide safe defaults for single-user machines.
 However, *do not expose the RemoteREPL port to an open network*. Abitrary
 remote code execution is the main feature provided by this package!
 
+## Interrupting remote evaluation
+
+When the RemoteREPL client is waiting on a response, it will catch
+`InterruptException` and forward it to the server as an interruption message.
+This allows blocking operations such as IO to be interrupted safely.
+
+However, this doesn't work for non-yielding operations such as tight
+computational loops. For these cases, pressing Control-C three times will
+disconnect from the server, leaving the remote operation still running.
+
 ## API reference
 
 ```@docs


### PR DESCRIPTION
This is implemented by catching InterruptException on the client while
it's blocked on reading from the socket. Then sending an interruption
message to the server before retrying the deserialization.

It's hard to make this fully reliable due to the way InterruptException
works in the Julia runtime:

* The InterruptException may be delivered to some random task on the
  client rather than the one waiting on the socket
* The InterruptException may occur in the middle of deserialization,
  corrupting the stream state
* The server side evaluation can only be interrupted at a yield point.
  Preemptive interruption (SIGINT) can't be implemented without a
  separate supervisor process, and even that would be likely to crash
  the server.

Fixes #16, to the extent that it can be fixed with the current Julia runtime.