### PR TITLE
Fix world age errors with show(eval_result)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RemoteREPL"
 uuid = "1bd9f7bb-701c-4338-bec7-ac987af7c555"
 authors = ["Chris Foster <chris42f@gmail.com> and contributors"]
-version = "0.2.9"
+version = "0.2.10"
 
 [deps]
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -141,6 +141,24 @@ try
     # Special case handling of stdout
     @test runcommand("println(@remote(stdout), \"hi\")") == "hi\n"
 
+    # Issue #26: world age errors showing output
+    @test runcommand("""
+        struct A
+        end
+
+        Base.show(io::IO, a::A) = print(io, "Surprise")
+
+        A()
+        """) == "Surprise"
+    @test occursin("Surprise", runcommand("""
+        struct MyExc <: Exception
+        end
+
+        Base.showerror(io::IO, e::MyExc) = print(io, "Surprise")
+
+        throw(MyExc())
+        """))
+
     # Execute a single command on a separate connection
     @test (RemoteREPL.remote_eval(test_interface, test_port, "asdf")::Text).content == "42"
 


### PR DESCRIPTION
We use `show` to format the user's evaluation result, but this is done
from outside of `eval` so we need to ensure it's running in the latest
world.

Fixes #26 