### PR TITLE
Add on_connect_hook to serve_repl for customized sessions

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RemoteREPL"
 uuid = "1bd9f7bb-701c-4338-bec7-ac987af7c555"
 authors = ["Chris Foster <chris42f@gmail.com> and contributors"]
-version = "0.2.11"
+version = "0.2.12"
 
 [deps]
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"


### PR DESCRIPTION
For now, this allows the server to set a custom module for the client to evaluate commands in.

This can be useful if you want
- The client to always start evaluating code in the server's module, for debugging
- Some minimal level of isolation between clients (a new anonymous module could be created for each client)