### PR TITLE
Add %include REPL magic for including a remote file

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RemoteREPL"
 uuid = "1bd9f7bb-701c-4338-bec7-ac987af7c555"
 authors = ["Chris Foster <chris42f@gmail.com> and contributors"]
-version = "0.2.14"
+version = "0.2.15"
 
 [deps]
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"

--- a/docs/src/howto.md
+++ b/docs/src/howto.md
@@ -74,6 +74,17 @@ Expr
     3: Symbol b
 ```
 
+## Include a remote file
+
+To include a Julia source file from the client into the current module on the
+remote side, use the `%include` REPL magic:
+
+```julia
+julia@localhost> %include some/file.jl
+```
+
+`%include` has tab completion for local paths on the client.
+
 ## Evaluate commands in another module
 
 If your server process has state in another module, you can tell RemoteREPL to

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -42,6 +42,10 @@ end
     # Module setting
     @test match_magic_syntax("%module xx") == ("%module", "xx")
     @test match_magic_syntax("  %module xx") == nothing
+
+    # Remote include
+    @test match_magic_syntax("%include /path/to/file") == ("%include", "/path/to/file")
+    @test match_magic_syntax("%include  /path /to/file") == ("%include", "/path /to/file")
 end
 
 @testset "Prompt text" begin
@@ -172,6 +176,11 @@ try
                         (:repl_completion, ("complete_m", "complete_m")))
     @test completion_msg[1] == :completion_result
     @test completion_msg[2] == ([], "complete_m", true)
+
+    # Remote include
+    path = joinpath(@__DIR__, "to_include.jl")
+    @test runcommand("%include $path") == "12345"
+    @test runcommand("var_in_included_file") == "12345"
 
     # Test the @remote macro
     Main.eval(:(clientside_var = 0:41))

--- a/test/to_include.jl
+++ b/test/to_include.jl
@@ -1,0 +1,1 @@
+var_in_included_file = 12345


### PR DESCRIPTION
From the docs:

> To include a Julia source file from the client into the current module on the
> remote side, use the `%include` REPL magic:
>
> ```julia
> julia@localhost> %include some/file.jl
> ```
>
> `%include` has tab completion for local paths on the client.

Fixes #37