### PR TITLE
Recursive %include from client side

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -181,6 +181,17 @@ try
     path = joinpath(@__DIR__, "to_include.jl")
     @test runcommand("%include $path") == "12345"
     @test runcommand("var_in_included_file") == "12345"
+    subinclude1_url = runcommand("var_in_subinclude1")
+    @test startswith(subinclude1_url, "\"file://$(gethostname())")
+    @test endswith(subinclude1_url, "subincludes/subinclude1.jl\"")
+    subinclude2_url = runcommand("var_in_subinclude2")
+    @test startswith(subinclude2_url, "\"file://$(gethostname())")
+    @test endswith(subinclude2_url, "subincludes/subinclude2.jl\"")
+    subinclude3_url = runcommand("IncludedModule.var_in_subinclude3")
+    @test startswith(subinclude3_url, "\"file://$(gethostname())")
+    @test endswith(subinclude3_url, "subincludes/subinclude3.jl\"")
+
+    @test_throws ErrorException runcommand("%include $(joinpath(@__DIR__, "to_include_bad_path.jl"))")
 
     # Test the @remote macro
     Main.eval(:(clientside_var = 0:41))

--- a/test/subincludes/subinclude1.jl
+++ b/test/subincludes/subinclude1.jl
@@ -1,0 +1,3 @@
+var_in_subinclude1 = @__FILE__
+
+include("subinclude2.jl")

--- a/test/subincludes/subinclude2.jl
+++ b/test/subincludes/subinclude2.jl
@@ -1,0 +1,1 @@
+var_in_subinclude2 = @__FILE__

--- a/test/subincludes/subinclude3.jl
+++ b/test/subincludes/subinclude3.jl
@@ -1,0 +1,1 @@
+var_in_subinclude3 = @__FILE__

--- a/test/to_include.jl
+++ b/test/to_include.jl
@@ -1,1 +1,7 @@
+include("subincludes/subinclude1.jl")
+
+module IncludedModule
+    include("subincludes/subinclude3.jl")
+end
+
 var_in_included_file = 12345

--- a/test/to_include_bad_path.jl
+++ b/test/to_include_bad_path.jl
@@ -1,0 +1,4 @@
+using Random
+
+some_path = "$(randstring()).jl"
+include(some_path)


### PR DESCRIPTION
This makes simple recursive uses of include(path) work for string
literal values of `path` by statically resolving all such includes on
the client side and passing the big composite expression which results
to the server.