### PR TITLE
Add specific argument types to connect_repl

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -52,7 +52,7 @@ end
     function fake_conn(host, port; is_open=true)
         io = IOBuffer()
         is_open || close(io)
-        RemoteREPL.Connection(host, port, nothing, nothing, nothing, nothing, io, :Main)
+        RemoteREPL.Connection(host, port, :none, ``, nothing, nothing, io, :Main)
     end
     @test repl_prompt_text(fake_conn(Sockets.localhost, DEFAULT_PORT)) == "julia@localhost> "
     @test repl_prompt_text(fake_conn("localhost",       DEFAULT_PORT)) == "julia@localhost> "


### PR DESCRIPTION
This should make it a little easier to see what's going wrong if the
wrong argument type is passed to ssh_opts or similar. Also specify
clearer field types in the `Connection` struct.

Fixes #40 