### PR TITLE
Add `connect_remote`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RemoteREPL"
 uuid = "1bd9f7bb-701c-4338-bec7-ac987af7c555"
 authors = ["Chris Foster <chris42f@gmail.com> and contributors"]
-version = "0.2.16"
+version = "0.2.17"
 
 [deps]
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"

--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -39,6 +39,7 @@ disconnect from the server, leaving the remote operation still running.
 ```@docs
 connect_repl
 serve_repl
+connect_remote
 RemoteREPL.@remote
 RemoteREPL.remote_eval
 ```

--- a/src/RemoteREPL.jl
+++ b/src/RemoteREPL.jl
@@ -1,6 +1,6 @@
 module RemoteREPL
 
-export connect_repl, serve_repl, @remote
+export connect_repl, serve_repl, @remote, connect_remote
 
 const DEFAULT_PORT = 27754
 const PROTOCOL_MAGIC = "RemoteREPL"

--- a/src/client.jl
+++ b/src/client.jl
@@ -11,7 +11,7 @@ function Base.showerror(io::IO, e::RemoteException)
     # Here, we presume that e.msg is fully formatted.
     indented_msg = join("  " .* split(e.msg, '\n'), '\n')
     print(io, "RemoteException:\n", indented_msg)
-end
+endPatch 1
 
 # Super dumb macro expander which expands calls to only a single macro
 # `macro_name` which is implemented as `func` taking the expressions passed to
@@ -441,18 +441,8 @@ function connect_repl(host=Sockets.localhost, port::Integer=DEFAULT_PORT;
                       namespace::Union{AbstractString,Nothing}=nothing,
                       startup_text::Bool=true,
                       repl=Base.active_repl)
-    global _repl_client_connection
 
-    if !isnothing(_repl_client_connection)
-        try
-            close(_repl_client_connection)
-        catch exc
-            @warn "Exception closing connection" exception=(exc,catch_backtrace())
-        end
-    end
-
-    conn = Connection(host=host, port=port, tunnel=tunnel,
-                      ssh_opts=ssh_opts, region=region, namespace=namespace)
+    conn = connect_remote(host, port; tunnel, ssh_opts, region,namespace)
     out_stream = stdout
     prompt = ReplMaker.initrepl(c->run_remote_repl_command(conn, out_stream, c),
                        repl         = Base.active_repl,
@@ -465,8 +455,6 @@ function connect_repl(host=Sockets.localhost, port::Integer=DEFAULT_PORT;
                        completion_provider = RemoteCompletionProvider(conn),
                        startup_text = startup_text
                        )
-    # Record the connection which is attached to the REPL
-    _repl_client_connection = conn
     prompt
 end
 
@@ -496,10 +484,10 @@ function connect_remote(host=Sockets.localhost, port::Integer=DEFAULT_PORT;
             @warn "Exception closing connection" exception=(exc,catch_backtrace())
         end
     end
-    out_stream = stdout
     conn = RemoteREPL.Connection(host=host, port=port, tunnel=tunnel,
                                  ssh_opts=ssh_opts, region=region, namespace=namespace)
 
+    # Record the connection in a global variable so it's accessible to REPL and `@remote`
     _repl_client_connection = conn
 end                       
 

--- a/src/client.jl
+++ b/src/client.jl
@@ -11,7 +11,7 @@ function Base.showerror(io::IO, e::RemoteException)
     # Here, we presume that e.msg is fully formatted.
     indented_msg = join("  " .* split(e.msg, '\n'), '\n')
     print(io, "RemoteException:\n", indented_msg)
-endPatch 1
+end
 
 # Super dumb macro expander which expands calls to only a single macro
 # `macro_name` which is implemented as `func` taking the expressions passed to

--- a/src/client.jl
+++ b/src/client.jl
@@ -467,7 +467,7 @@ connect_repl(port::Integer) = connect_repl(Sockets.localhost, port)
 
 Connect to remote server without any REPL integrations. This will allow you to use `@remote`, but not the REPL mode.
 Useful in circumstances where no REPL is available, but interactivity is desired like Jupyter or Pluto notebooks.
-Otherwise, see `connece_repl`.
+Otherwise, see `connect_repl`.
 """
 function connect_remote(host=Sockets.localhost, port::Integer=DEFAULT_PORT;
                         tunnel::Symbol = host!=Sockets.localhost ? :ssh : :none,


### PR DESCRIPTION
This is basically just `connect_repl`, but without any REPL integrations. I found myself wanting this while interacting with a remote process from a Jupyter kernel where `Base.active_repl` is not defined. 