### PR TITLE
Module update

### DIFF
--- a/src/RemoteREPL.jl
+++ b/src/RemoteREPL.jl
@@ -1,12 +1,13 @@
 module RemoteREPL
 
-export connect_repl, serve_repl, @remote, connect_remote
+export connect_repl, serve_repl, @remote, connect_remote, putmodule!
 
 const DEFAULT_PORT = 27754
 const PROTOCOL_MAGIC = "RemoteREPL"
 const PROTOCOL_VERSION = UInt32(1)
 
 const STDOUT_PLACEHOLDER = Symbol("#RemoteREPL_STDOUT_PLACEHOLDER")
+const NEWMODULE_CHANNEL = Channel{Module}(1)
 
 include("tunnels.jl")
 include("server.jl")


### PR DESCRIPTION
Hello. Thanks for the awesome package :)
I 've been playing around to get RemoteREPL.jl to work well with Pluto. 

The problem with Pluto is that everytime there is a change/evaluation in the notebook it creates a new Module.
So the client must explicitly change the module where the commands should be evaluated and that's tedious.

I tried to think of a non-intrusive way to solve this, but I couldn't wrap my head around it.
Instead here is an example of how RemoteREPL.jl could be modified.
Right now I have a global `const Channel` that the server can asynchronously modify with the `putmodule!` command.

# Pluto side
You can see a Pluto notebook on [gist](https://gist.github.com/filchristou/fa42af6197be9edd541e79ab7764ee2a)
Basically it steps on the PlutoLinks.jl / PlutoHooks.jl to schedule an update of the module of RemoteREPL (with `putmodule!`) every second.
(I think this could be more clever but it's just a minimal working example)

# Test
Run Pluto notebook and from the REPL do:
```julia
julia> using RemoteREPL, Sockets

julia> connect_repl(27755)
REPL mode remote_repl initialized. Press > to enter and backspace to exit.
"Prompt(\"julia@localhost:27755> \",...)"

julia@localhost:27755> @__MODULE__ # module changes automatically
Main.var"workspace#517"

julia@localhost:27755> @__MODULE__ # module changes automatically
Main.var"workspace#518"

julia> @remote(anewvar)
1
```

The RemoteREPL now will always be on the last update of the Pluto notebook.

This is just a draft. 
I myself am not very happy with the restriction to have only one global Channel, 
but before I move on I would like to know what do you think.
So basically two questions:
- Are you at all interested in any changes in this direction ?
- If yes, do you have any preferences for the implementation ? I will be happy to take them into consideration.